### PR TITLE
Stop passing worker_id around all over the f**king place

### DIFF
--- a/dockets/docket.py
+++ b/dockets/docket.py
@@ -67,9 +67,9 @@ class Docket(Queue):
 
 
     @PipelineObject.with_pipeline
-    def pop(self, worker_id, pipeline, current_time=None):
+    def pop(self, pipeline, current_time=None):
         next_envelope = None
-        self._record_worker_activity(worker_id)
+        self._record_worker_activity()
         with self.redis.pipeline() as pop_pipeline:
             while True:
                 try:
@@ -105,7 +105,7 @@ class Docket(Queue):
                     pop_pipeline.multi()
                     pop_pipeline.zrem(self._queue_key(), next_envelope_key)
                     pop_pipeline.hdel(self._payload_key(), next_envelope_key)
-                    pop_pipeline.lpush(self._working_queue_key(worker_id),
+                    pop_pipeline.lpush(self._working_queue_key(),
                                        next_envelope_json)
                     pop_pipeline.execute()
                     break
@@ -124,8 +124,8 @@ class Docket(Queue):
             return pipeline.execute()[0]
 
     @PipelineObject.with_pipeline
-    def complete(self, envelope, worker_id, pipeline):
-        super(Docket, self).complete(envelope, worker_id, pipeline=pipeline)
+    def complete(self, envelope, pipeline):
+        super(Docket, self).complete(envelope, pipeline=pipeline)
 
     def _reclaim_worker_queue(self, worker_id):
         working_contents = self.redis.lrange(self._working_queue_key(worker_id),

--- a/test/isolation_queue_test.py
+++ b/test/isolation_queue_test.py
@@ -97,7 +97,7 @@ def test_push_twice_same_key_run_once():
     queue = make_queue()
     queue.push({'a': 1, 'b': 1})
     queue.push({'a': 1, 'b': 2})
-    queue.run_once(worker_id='test_worker')
+    queue.run_once()
     assert queue.queued() == 1
     assert redis.get('queue.test.entry.1') == '1'
     assert not queue.redis.hgetall('queue.test.latest')
@@ -108,8 +108,8 @@ def test_push_twice_same_key_run_twice():
     queue = make_queue()
     queue.push({'a': 1, 'b': 1})
     queue.push({'a': 1, 'b': 2})
-    queue.run_once(worker_id='test_worker')
-    queue.run_once(worker_id='test_worker')
+    queue.run_once()
+    queue.run_once()
     assert queue.queued() == 0
     assert not redis.get('queue.test.entry.1')
     assert not redis.hgetall('queue.test.latest')
@@ -119,12 +119,12 @@ def test_push_twice_same_key_run_twice():
 def test_delete_from_error_queue():
     queue = make_queue()
     queue.push({'a': 1, 'b': 1, 'action': 'error'})
-    queue.run_once(worker_id='test_worker')
+    queue.run_once()
     assert queue.queued() == 0
     assert queue.error_queue.length() == 1
     queue.error_queue.delete_error(queue.error_queue.error_ids()[0])
     queue.push({'a': 1, 'b': 2})
-    queue.run_once(worker_id='test_worker')
+    queue.run_once()
     assert queue.queued() == 0
     assert not redis.get('queue.test.entry.1')
     assert not redis.hgetall('queue.test.latest')


### PR DESCRIPTION
Just set it as a member variable when the queue is instantiated. Makes queue code and tests simpler. @thieman 
