### PR TITLE
Enhance reclaim to increment the number of attempts

### DIFF
--- a/test/basic_queue_test.py
+++ b/test/basic_queue_test.py
@@ -356,7 +356,7 @@ def push_once_reclaim_once_unset_worker_key_reclaim(queue):
     redis.delete(queue._worker_activity_key())
     queue._reclaim()
     assert queue.queued() == 1
-    assert_queue_entry(queue.queued_items()[0], {'a': 1})
+    assert_queue_entry(queue.queued_items()[0], {'a': 1}, attempts=1)
 
 def run_bad_worker(queue):
     queue.push({'a': 1})

--- a/test/util.py
+++ b/test/util.py
@@ -6,15 +6,18 @@ from redis import Redis
 redis = Redis(host=os.getenv('REDIS_HOST', 'localhost'), port=int(os.getenv('REDIS_PORT', 6379)),
               db=int(os.getenv('REDIS_DB', 0)))
 
-def assert_queue_entry(json, item):
+def assert_queue_entry(json, item, **envelope_keys):
     assert isinstance(json, basestring)
     entry = simplejson.loads(json)
     assert isinstance(entry, dict)
     assert 'ts' in entry
     assert 'first_ts' in entry
+    assert 'attempts' in entry
     assert 'v' in entry
     assert 'item' in entry
     assert entry['item'] == item
+    for key, value in envelope_keys.iteritems():
+        assert entry[key] == value, '{} != {}'.format(entry[key], value)
 
 def assert_error_queue_empty(queue):
     assert not queue.error_queue.errors()


### PR DESCRIPTION
@thieman 

Queues already contain a mechanism to place an item on the error queue if attempted too many times. In this instance we're essentially treating a reclaim as an error (on the premise that some errors don't result in Exceptions, they take down the queue processor completely).
