### PR TITLE
Implemented a delayed item feature for queues

### DIFF
--- a/dockets/docket.py
+++ b/dockets/docket.py
@@ -12,8 +12,6 @@ from dockets.queue import Queue
 
 
 class Docket(Queue):
-    def _payload_key(self):
-        return '{0}.payload'.format(self._queue_key())
 
     def push(self, item, pipeline=None, when=None, envelope=None,
              max_attempts=None, attempts=None, error_classes=None):

--- a/dockets/queue.py
+++ b/dockets/queue.py
@@ -101,7 +101,7 @@ class Queue(PipelineObject):
             pipeline.watch(self._delayed_queue_key())
             try:
                 next_envelope_key, timestamp = pipeline.zrange(
-                    self._delayed_queue_key(), 0, 3, withscores=True)[0]
+                    self._delayed_queue_key(), 0, 1, withscores=True)[0]
                 if time.time() < timestamp:
                     # It's not yet that time.
                     return

--- a/dockets/queue.py
+++ b/dockets/queue.py
@@ -93,11 +93,38 @@ class Queue(PipelineObject):
                             for key_component in self.key)
         return str(item)
 
+    def move_delayed_item(self):
+        pipeline = self.redis.pipeline()
+
+        # Move any due delayed items to the main working list
+        try:
+            pipeline.watch(self._delayed_queue_key())
+            try:
+                next_envelope_key, timestamp = pipeline.zrange(
+                    self._delayed_queue_key(), 0, 3, withscores=True)[0]
+                if time.time() < timestamp:
+                    # It's not yet that time.
+                    return
+                envelope = pipeline.hget(self._payload_key(), next_envelope_key)
+                pipeline.multi()
+                if self.mode == self.FIFO:
+                    pipeline.lpush(self._queue_key(), envelope)
+                else:
+                    pipeline.rpush(self._queue_key(), envelope)
+                pipeline.zrem(self._delayed_queue_key(), next_envelope_key)
+                pipeline.hdel(self._payload_key(), next_envelope_key)
+                pipeline.execute()
+
+            except IndexError:
+                pass # Empty set - move on with our lives
+        except WatchError:
+            pass
 
     ## public methods
 
     @PipelineObject.with_pipeline
     def pop(self, pipeline):
+        self.move_delayed_item()
         pop_pipeline = self.redis.pipeline()
         args = [self._queue_key(), self._working_queue_key(), self._wait_time]
         pop_pipeline.execute()
@@ -116,7 +143,7 @@ class Queue(PipelineObject):
 
     @PipelineObject.with_pipeline
     def push(self, item, pipeline, first_ts=None, ttl=None, envelope=None,
-             max_attempts=None, attempts=0, error_classes=None):
+             max_attempts=None, attempts=0, error_classes=None, delay=None):
         envelope = {'first_ts': first_ts or (envelope and envelope['first_ts'])
                     or time.time(),
                     'ts': time.time(),
@@ -127,10 +154,18 @@ class Queue(PipelineObject):
                     'max_attempts': max_attempts or self._max_attempts,
                     'error_classes': pickle.dumps(error_classes)}
         serialized_envelope = self._serializer.serialize(envelope)
-        if self.mode == self.FIFO:
-            pipeline.lpush(self._queue_key(), serialized_envelope)
+
+        if delay is not None:
+            timestamp = time.time() + delay
+            key = self.item_key(item)
+            pipeline.hset(self._payload_key(), key, serialized_envelope)
+            pipeline.zadd(self._delayed_queue_key(), key, timestamp)
         else:
-            pipeline.rpush(self._queue_key(), serialized_envelope)
+            if self.mode == self.FIFO:
+                pipeline.lpush(self._queue_key(), serialized_envelope)
+            else:
+                pipeline.rpush(self._queue_key(), serialized_envelope)
+
         self._event_registrar.on_push(
             item=item,
             item_key=self.item_key(item),
@@ -345,6 +380,12 @@ class Queue(PipelineObject):
 
     def _queue_key(self):
         return 'queue.{0}'.format(self.name)
+
+    def _payload_key(self):
+        return '{0}.payload'.format(self._queue_key())
+
+    def _delayed_queue_key(self):
+        return 'queue.{0}.delayed'.format(self.name)
 
     def _workers_set_key(self):
         return 'queue.{0}.workers'.format(self.name)

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
     url="http://github.com/gamechanger/dockets",
     packages=["dockets"],
     long_description="LONG",
-    install_requires=['simplejson','redis','python-dateutil'],
+    install_requires=['simplejson','redis>=2.10','python-dateutil'],
     test_suite = 'nose.collector',
     tests_require=['nose', 'mock']
 )


### PR DESCRIPTION
This PR adds a feature which allows the execution of a given item to be delayed by a number of seconds provided on `push`. 
Example:
```python
queue.push(item, delay=10)  # this item will only become available for workers to push after 10 seconds
```
This is implemented using a separate combination of a sorted set and a hash in a vary similar vein to the `Docket` class (only the timestamp is inferred rather than provided). On each pop we try and move at most one item from the delayed sorted set / hash to the main queue list. Then the standard `BRPOPLPUSH` stuff takes over. 