### PR TITLE
Don't add LoggingEventHandler by default

### DIFF
--- a/dockets/__init__.py
+++ b/dockets/__init__.py
@@ -18,8 +18,6 @@ def add_global_event_handler(handler_class):
 def clear_global_event_handlers():
     _global_event_handler_classes.clear()
 
-add_global_event_handler(LoggingEventHandler)
-
 
 _global_retry_error_classes = set()
 


### PR DESCRIPTION
Review @tleach 

While the logging event handler has utility for debugging, it's rather verbose and should probably be opt-in.