### PR TITLE
Split out error queue push into its own separate function

### DIFF
--- a/dockets/__init__.py
+++ b/dockets/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.3.0'
+__version__ = '0.3.1'
 
 import logging
 from dockets.logging_event_handler import LoggingEventHandler

--- a/dockets/error_queue.py
+++ b/dockets/error_queue.py
@@ -20,7 +20,7 @@ class ErrorQueue(PipelineObject):
         super(ErrorQueue, self).__init__(main_queue.redis)
 
     @PipelineObject.with_pipeline
-    def push_error(self, error_id, error_item, pipeline):
+    def queue_error_item(self, error_id, error_item, pipeline):
         pipeline.hset(self._hash_key(), error_id, self._serializer.serialize(error_item))
 
     @PipelineObject.with_pipeline
@@ -41,7 +41,7 @@ class ErrorQueue(PipelineObject):
                       'ts': time.time(),
                       'id': error_id}
 
-        self.push_error(error_id, error_item, pipeline=pipeline)
+        self.queue_error_item(error_id, error_item, pipeline=pipeline)
 
     def requeue_error(self, error_id):
         error = self._serializer.deserialize(self.redis.hget(self._hash_key(), error_id))


### PR DESCRIPTION
@inlinestyle cc @tleach 

I need to be able to do a push to the error queue without it going through all the Dockets-specific processing, hence this function. A few notes:

1. I believe I have to pass `pipeline` as a kwarg for it to be properly handled in the `with_pipeline` decorator.
1. I would have written a test, but turns out the error queue doesn't have its own tests LOL