### PR TITLE
Throw warning if data doesn't perfectly match our expected format

### DIFF
--- a/dockets/__init__.py
+++ b/dockets/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.3.1'
+__version__ = '0.3.2'
 
 import logging
 from dockets.logging_event_handler import LoggingEventHandler

--- a/dockets/error_queue.py
+++ b/dockets/error_queue.py
@@ -59,10 +59,8 @@ class ErrorQueue(PipelineObject):
 
     def delete_error(self, error_id):
         error = self.error(error_id)
-        try:
+        if 'envelope' in error:
             self.queue.delete(error['envelope'])
-        except KeyError:
-            logging.warn('Error has no envelope, skipping delete callback: {}'.format(error))
         return self.redis.hdel(self._hash_key(), error_id)
 
     def errors(self):

--- a/dockets/error_queue.py
+++ b/dockets/error_queue.py
@@ -3,6 +3,7 @@ import sys
 import time
 from uuid import uuid1
 from traceback import format_exc
+import logging
 
 from dockets.pipeline import PipelineObject
 
@@ -57,7 +58,11 @@ class ErrorQueue(PipelineObject):
             self.requeue_error(error_id)
 
     def delete_error(self, error_id):
-        self.queue.delete(self.error(error_id)['envelope'])
+        error = self.error(error_id)
+        try:
+            self.queue.delete(error['envelope'])
+        except KeyError:
+            logging.warn('Error has no envelope, skipping delete callback: {}'.format(error))
         return self.redis.hdel(self._hash_key(), error_id)
 
     def errors(self):


### PR DESCRIPTION
@inlinestyle Dockets isn't allowed to stipulate shit like the `envelope` key existing when you're using it as a dumb queuing library.