### PR TITLE
Enable non-blocking RPOPLPUSH (mostly for fast testing)

### DIFF
--- a/dockets/__init__.py
+++ b/dockets/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.3.2'
+__version__ = '0.3.3'
 
 import logging
 from dockets.logging_event_handler import LoggingEventHandler

--- a/dockets/docket.py
+++ b/dockets/docket.py
@@ -71,7 +71,8 @@ class Docket(Queue):
                     except IndexError:
                         # Simulate a blocking ZRANGE by sleeping if there is nothing returned.
                         # This ensures we aren't hammering Redis.
-                        sleep(self._wait_time)
+                        if self._wait_time >= 0:
+                            sleep(self._wait_time)
                         return
 
                     next_envelope_json = pop_pipeline.hget(self._payload_key(),
@@ -91,7 +92,8 @@ class Docket(Queue):
                     if next_envelope['when'] > (current_time or time.time()):
                         # Simulate a blocking call by sleeping if there is nothing returned.
                         # This ensures we aren't hammering Redis.
-                        sleep(self._wait_time)
+                        if self._wait_time >= 0:
+                            sleep(self._wait_time)
                         return None
 
                     pop_pipeline.multi()
@@ -147,5 +149,3 @@ class Docket(Queue):
                 return float(when)
         except:
             raise TypeError('Invalid time specification', when)
-
-

--- a/dockets/queue.py
+++ b/dockets/queue.py
@@ -113,7 +113,7 @@ class Queue(PipelineObject):
         pop_pipeline = self.redis.pipeline()
         pop_pipeline.execute()
 
-        args = [self._queue_key(), self._working_queue_key(), self._wait_time]
+        args = [self._queue_key(), self._working_queue_key()]
         if isinstance(self._wait_time, int) and self._wait_time >= 10:
             op = self.redis.brpoplpush
             args.append(self._wait_time)

--- a/dockets/queue.py
+++ b/dockets/queue.py
@@ -111,9 +111,16 @@ class Queue(PipelineObject):
     def pop(self, pipeline):
         self.pop_delayed_items(pipeline)
         pop_pipeline = self.redis.pipeline()
-        args = [self._queue_key(), self._working_queue_key(), self._wait_time]
         pop_pipeline.execute()
-        serialized_envelope = self.redis.brpoplpush(*args)
+
+        args = [self._queue_key(), self._working_queue_key(), self._wait_time]
+        if isinstance(self._wait_time, int) and self._wait_time >= 10:
+            op = self.redis.brpoplpush
+            args.append(self._wait_time)
+        else:
+            op = self.redis.rpoplpush
+
+        serialized_envelope = op(*args)
         if not serialized_envelope:
             return None
         try:

--- a/dockets/queue.py
+++ b/dockets/queue.py
@@ -114,7 +114,7 @@ class Queue(PipelineObject):
         pop_pipeline.execute()
 
         args = [self._queue_key(), self._working_queue_key()]
-        if isinstance(self._wait_time, int) and self._wait_time >= 10:
+        if isinstance(self._wait_time, int) and self._wait_time >= 0:
             op = self.redis.brpoplpush
             args.append(self._wait_time)
         else:

--- a/test/basic_queue_test.py
+++ b/test/basic_queue_test.py
@@ -52,12 +52,13 @@ class TestDocket(Docket):
 def clear_redis():
     redis.flushdb()
 
-def make_queue(cls):
-    queue = cls(redis, 'test', use_error_queue=True,
-                retry_error_classes=[TestRetryError],
-                max_attempts=5, wait_time=1, heartbeat_interval=0.01)
-    queue.worker_id = 'test_worker'
-    return queue
+def make_queues(cls):
+    for wait_time in [-1, 1]:
+        queue = cls(redis, 'test', use_error_queue=True,
+                    retry_error_classes=[TestRetryError],
+                    max_attempts=5, wait_time=wait_time, heartbeat_interval=0.01)
+        queue.worker_id = 'test_worker'
+        yield queue
 
 all_queue_tests = []
 
@@ -426,58 +427,60 @@ def run_should_raise_if_heartbeat_thread_dies(queue):
 
 @with_setup(clear_redis)
 def test_delayed_item_should_not_be_immediately_available():
-    queue = make_queue(TestQueue)
-    queue.push({'a': 1}, delay=1)
-    item = queue.pop()
-    assert item is None
+    for queue in make_queues(TestQueue):
+        queue.push({'a': 1}, delay=1)
+        item = queue.pop()
+        assert item is None
 
 @with_setup(clear_redis)
 def test_delayed_item_executed_after_delay():
-    queue = make_queue(TestQueue)
-    queue.push({'a': 1}, delay=1)
-    sleep(1)
-    item = queue.pop()
-    assert item['item'] == {'a': 1}
+    for queue in make_queues(TestQueue):
+        queue.push({'a': 1}, delay=1)
+        sleep(1)
+        item = queue.pop()
+        assert item['item'] == {'a': 1}
 
 @with_setup(clear_redis)
 def test_multiple_delayed_items():
-    queue = make_queue(TestQueue)
-    queue.push({'a': 1}, delay=1)
-    queue.push({'a': 2}, delay=0.1)
-    queue.push({'a': 3}, delay=0.5)
-    sleep(0.1)
-    item = queue.pop()
-    assert item['item'] == {'a': 2}
-    sleep(0.4)
-    item = queue.pop()
-    assert item['item'] == {'a': 3}
-    sleep(0.5)
-    item = queue.pop()
-    assert item['item'] == {'a': 1}
+    for queue in make_queues(TestQueue):
+        queue.push({'a': 1}, delay=1)
+        queue.push({'a': 2}, delay=0.1)
+        queue.push({'a': 3}, delay=0.5)
+        sleep(0.1)
+        item = queue.pop()
+        assert item['item'] == {'a': 2}
+        sleep(0.4)
+        item = queue.pop()
+        assert item['item'] == {'a': 3}
+        sleep(0.5)
+        item = queue.pop()
+        assert item['item'] == {'a': 1}
 
 @with_setup(clear_redis)
 def test_delayed_item_count():
-    queue = make_queue(TestQueue)
-    queue.push({'a': 1}, delay=1)
-    queue.push({'a': 2}, delay=0.1)
-    queue.push({'a': 3}, delay=0.5)
-    assert 3 == queue.delayed()
+    for queue in make_queues(TestQueue):
+        queue.push({'a': 1}, delay=1)
+        queue.push({'a': 2}, delay=0.1)
+        queue.push({'a': 3}, delay=0.5)
+        assert 3 == queue.delayed()
+        queue.redis.delete(queue._delayed_queue_key())
 
 @with_setup(clear_redis)
 def test_multiple_delayed_items_same_data():
-    queue = make_queue(TestQueue)
-    queue.push({'a': 1}, delay=0.05)
-    queue.push({'a': 1}, delay=0.1)
-    queue.push({'a': 1}, delay=0.15)
-    sleep(0.2)
-    item = queue.pop()
-    assert item is not None
-    item = queue.pop()
-    assert item is not None
-    item = queue.pop()
-    assert item is not None
+    for queue in make_queues(TestQueue):
+        queue.push({'a': 1}, delay=0.05)
+        queue.push({'a': 1}, delay=0.1)
+        queue.push({'a': 1}, delay=0.15)
+        sleep(0.2)
+        item = queue.pop()
+        assert item is not None
+        item = queue.pop()
+        assert item is not None
+        item = queue.pop()
+        assert item is not None
 
 def test_all_queues():
     for cls in (TestQueue, TestIsolationQueue, TestDocket):
         for test_case in all_queue_tests:
-            yield test_case, make_queue(cls)
+            for queue in make_queues(cls):
+                yield test_case, queue

--- a/test/basic_queue_test.py
+++ b/test/basic_queue_test.py
@@ -54,8 +54,8 @@ def clear_redis():
 
 def make_queue(cls):
     queue = cls(redis, 'test', use_error_queue=True,
-               retry_error_classes=[TestRetryError],
-               max_attempts=5, wait_time=1, heartbeat_interval=0.01)
+                retry_error_classes=[TestRetryError],
+                max_attempts=5, wait_time=1, heartbeat_interval=0.01)
     queue.worker_id = 'test_worker'
     return queue
 


### PR DESCRIPTION
@inlinestyle This is slightly janky, it preserves the current API but to enable non-blocking RPOPLPUSH you need to pass `-1` or something as the wait_time arg. Fast tests tho.