### PR TITLE
Remove the ability to RPOPLPUSH rather than BRPOPLPUSH.

### DIFF
--- a/dockets/queue.py
+++ b/dockets/queue.py
@@ -115,14 +115,7 @@ class Queue(PipelineObject):
         pop_pipeline = self.redis.pipeline()
         pop_pipeline.execute()
 
-        args = [self._queue_key(), self._working_queue_key()]
-        if isinstance(self._wait_time, int) and self._wait_time >= 0:
-            op = self.redis.brpoplpush
-            args.append(self._wait_time)
-        else:
-            op = self.redis.rpoplpush
-
-        serialized_envelope = op(*args)
+        serialized_envelope = self.redis.brpoplpush(self._queue_key(), self._working_queue_key(), self._wait_time)
         if not serialized_envelope:
             return None
         try:

--- a/test/basic_queue_test.py
+++ b/test/basic_queue_test.py
@@ -52,13 +52,12 @@ class TestDocket(Docket):
 def clear_redis():
     redis.flushdb()
 
-def make_queues(cls):
-    for wait_time in [-1, 1]:
-        queue = cls(redis, 'test', use_error_queue=True,
-                    retry_error_classes=[TestRetryError],
-                    max_attempts=5, wait_time=wait_time, heartbeat_interval=0.01)
-        queue.worker_id = 'test_worker'
-        yield queue
+def make_queue(cls):
+    queue = cls(redis, 'test', use_error_queue=True,
+                retry_error_classes=[TestRetryError],
+                max_attempts=5, wait_time=1, heartbeat_interval=0.01)
+    queue.worker_id = 'test_worker'
+    return queue
 
 all_queue_tests = []
 
@@ -146,7 +145,6 @@ def push_once_run_once(queue):
     metadata = redis.hgetall('queue.test.test_worker.metadata')
     assert metadata
     assert 'start_ts' in metadata
-    print metadata
     assert int(metadata['success']) == 1
     assert_error_queue_empty(queue)
 
@@ -165,8 +163,8 @@ def push_twice_run_twice(queue):
     queue.run_once()
     queue.run_once()
 
-    assert queue.items_processed == [{'a': 1}, {'b': 2}]
     assert queue.queued() == 0
+    assert queue.items_processed == [{'a': 1}, {'b': 2}]
     assert_error_queue_empty(queue)
     metadata = redis.hgetall('queue.test.test_worker.metadata')
     assert metadata
@@ -427,60 +425,59 @@ def run_should_raise_if_heartbeat_thread_dies(queue):
 
 @with_setup(clear_redis)
 def test_delayed_item_should_not_be_immediately_available():
-    for queue in make_queues(TestQueue):
-        queue.push({'a': 1}, delay=1)
-        item = queue.pop()
-        assert item is None
+    queue = make_queue(TestQueue)
+    queue.push({'a': 1}, delay=1)
+    item = queue.pop()
+    assert item is None
 
 @with_setup(clear_redis)
 def test_delayed_item_executed_after_delay():
-    for queue in make_queues(TestQueue):
-        queue.push({'a': 1}, delay=1)
-        sleep(1)
-        item = queue.pop()
-        assert item['item'] == {'a': 1}
+    queue = make_queue(TestQueue)
+    queue.push({'a': 1}, delay=1)
+    sleep(1)
+    item = queue.pop()
+    assert item['item'] == {'a': 1}
 
 @with_setup(clear_redis)
 def test_multiple_delayed_items():
-    for queue in make_queues(TestQueue):
-        queue.push({'a': 1}, delay=1)
-        queue.push({'a': 2}, delay=0.1)
-        queue.push({'a': 3}, delay=0.5)
-        sleep(0.1)
-        item = queue.pop()
-        assert item['item'] == {'a': 2}
-        sleep(0.4)
-        item = queue.pop()
-        assert item['item'] == {'a': 3}
-        sleep(0.5)
-        item = queue.pop()
-        assert item['item'] == {'a': 1}
+    queue = make_queue(TestQueue)
+    queue.push({'a': 1}, delay=1)
+    queue.push({'a': 2}, delay=0.1)
+    queue.push({'a': 3}, delay=0.5)
+    sleep(0.1)
+    item = queue.pop()
+    assert item['item'] == {'a': 2}
+    sleep(0.4)
+    item = queue.pop()
+    assert item['item'] == {'a': 3}
+    sleep(0.5)
+    item = queue.pop()
+    assert item['item'] == {'a': 1}
 
 @with_setup(clear_redis)
 def test_delayed_item_count():
-    for queue in make_queues(TestQueue):
-        queue.push({'a': 1}, delay=1)
-        queue.push({'a': 2}, delay=0.1)
-        queue.push({'a': 3}, delay=0.5)
-        assert 3 == queue.delayed()
-        queue.redis.delete(queue._delayed_queue_key())
+    queue = make_queue(TestQueue)
+    queue.push({'a': 1}, delay=1)
+    queue.push({'a': 2}, delay=0.1)
+    queue.push({'a': 3}, delay=0.5)
+    assert 3 == queue.delayed()
+    queue.redis.delete(queue._delayed_queue_key())
 
 @with_setup(clear_redis)
 def test_multiple_delayed_items_same_data():
-    for queue in make_queues(TestQueue):
-        queue.push({'a': 1}, delay=0.05)
-        queue.push({'a': 1}, delay=0.1)
-        queue.push({'a': 1}, delay=0.15)
-        sleep(0.2)
-        item = queue.pop()
-        assert item is not None
-        item = queue.pop()
-        assert item is not None
-        item = queue.pop()
-        assert item is not None
+    queue = make_queue(TestQueue)
+    queue.push({'a': 1}, delay=0.05)
+    queue.push({'a': 1}, delay=0.1)
+    queue.push({'a': 1}, delay=0.15)
+    sleep(0.2)
+    item = queue.pop()
+    assert item is not None
+    item = queue.pop()
+    assert item is not None
+    item = queue.pop()
+    assert item is not None
 
 def test_all_queues():
     for cls in (TestQueue, TestIsolationQueue, TestDocket):
         for test_case in all_queue_tests:
-            for queue in make_queues(cls):
-                yield test_case, queue
+            yield test_case, make_queue(cls)


### PR DESCRIPTION
@inlinestyle We only kept this in to keep Doug happy, but it was always a non-starter. Ripping it out simplifies the code and the tests.