### PR TITLE
Fix bug in reclaim.

### DIFF
--- a/dockets/queue.py
+++ b/dockets/queue.py
@@ -383,8 +383,8 @@ class Queue(PipelineObject):
     def _working_queue_key(self, worker_id=None):
         return 'queue.{0}.{1}.working'.format(self.name, worker_id or self.worker_id)
 
-    def _worker_activity_key(self):
-        return 'queue.{0}.{1}.active'.format(self.name, self.worker_id)
+    def _worker_activity_key(self, worker_id=None):
+        return 'queue.{0}.{1}.active'.format(self.name, worker_id or self.worker_id)
 
     ## worker handling
 
@@ -392,7 +392,7 @@ class Queue(PipelineObject):
     def _reclaim(self):
         workers = self.redis.smembers(self._workers_set_key())
         for worker_id in workers:
-            if not self.redis.exists(self._worker_activity_key()):
+            if not self.redis.exists(self._worker_activity_key(worker_id)):
                 self._reclaim_worker_queue(worker_id)
                 self.redis.srem(self._workers_set_key(), worker_id)
 

--- a/test/basic_queue_test.py
+++ b/test/basic_queue_test.py
@@ -349,6 +349,17 @@ def push_once_reclaim_once_unset_worker_key_reclaim(queue):
     assert queue.queued() == 1
     assert_queue_entry(queue.queued_items()[0], {'a': 1}, attempts=1)
 
+@register
+def reclaim_from_other_worker(queue):
+    other_queue = make_queue(queue.__class__)
+    queue._heartbeat()
+    queue.push({'a': 1})
+    queue.pop()
+    redis.delete(queue._worker_activity_key())
+    other_queue._reclaim()
+    assert queue.queued() == 1
+    assert_queue_entry(queue.queued_items()[0], {'a': 1}, attempts=1)
+
 def run_bad_worker(queue):
     queue.push({'a': 1})
     def bad_process_item(item):


### PR DESCRIPTION
@inlinestyle 

Basically we were checking for activity of the _current_ worker, not the other workers being enumerated. So we never reclaimed anything.
In an extreme case where the worker's own activity key disappears (due to load?) then everything got reclaimed.