### PR TITLE
Reinstate ability to specify zero wait time

### DIFF
--- a/dockets/docket.py
+++ b/dockets/docket.py
@@ -71,7 +71,7 @@ class Docket(Queue):
                     except IndexError:
                         # Simulate a blocking ZRANGE by sleeping if there is nothing returned.
                         # This ensures we aren't hammering Redis.
-                        if self._wait_time >= 0:
+                        if self._wait_time > 0:
                             sleep(self._wait_time)
                         return
 
@@ -92,7 +92,7 @@ class Docket(Queue):
                     if next_envelope['when'] > (current_time or time.time()):
                         # Simulate a blocking call by sleeping if there is nothing returned.
                         # This ensures we aren't hammering Redis.
-                        if self._wait_time >= 0:
+                        if self._wait_time > 0:
                             sleep(self._wait_time)
                         return None
 

--- a/test/basic_queue_test.py
+++ b/test/basic_queue_test.py
@@ -47,7 +47,7 @@ def clear_redis():
 def make_queue(cls):
     queue = cls(redis, 'test', use_error_queue=True,
                 retry_error_classes=[TestRetryError],
-                max_attempts=5, wait_time=1, heartbeat_interval=0.01)
+                max_attempts=5, wait_time=0, heartbeat_interval=0.01)
     queue.worker_id = 'test_worker'
     return queue
 


### PR DESCRIPTION
@inlinestyle I was perhaps a little hasty in removing this. Being able to specify a non-blocking pop is needed (mostly for testing) and aligns with what the SQS API does as well. 

I've reconstituted it slightly differently. You can specify a `wait_time` of `0` to indicate a non-blocking pop. Previously you had to set a magic `-1` value to get this behaviour (`0` would block indefinitely which is never what you want). This is now hopefully more sane. 